### PR TITLE
Ensure compatibility with older Ansible versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,7 @@
   register: sosreport_find_sosreports
 
 - name: run sosreport
-  ansible.builtin.command:
-    cmd: "{{ sosreport_command }}"
+  command: "{{ sosreport_command }}"
   tags:
     - skip_ansible_lint
   when:


### PR DESCRIPTION
---
name: Ensure compatibility with older Ansible versions
about: Uses the short/flat command module instead of the one with the full namespace. This is fully compatible with the tested versions mentioned below.

---
**Describe the change**
Improves compatiblity with older Ansible versions.
Fixes #1 

**Testing**
Tested with 2.9.6 (ubuntu focal default)
Tested with 2.11.1 (pip installed, latest)
